### PR TITLE
adding psycog binary/pool; fixing PostgresContainer field names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea
 venv/
 .pytest_cache/
-
+__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ iniconfig==2.0.0
 packaging==24.0
 pluggy==1.5.0
 psycopg==3.1.18
+psycopg-binary==3.1.18
+psycopg-pool==3.2.2
 pytest==8.1.1
 requests==2.31.0
 testcontainers==4.4.0

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -18,9 +18,9 @@ def setup(request):
     os.environ["DB_CONN"] = postgres.get_connection_url()
     os.environ["DB_HOST"] = postgres.get_container_host_ip()
     os.environ["DB_PORT"] = postgres.get_exposed_port(5432)
-    os.environ["DB_USERNAME"] = postgres.POSTGRES_USER
-    os.environ["DB_PASSWORD"] = postgres.POSTGRES_PASSWORD
-    os.environ["DB_NAME"] = postgres.POSTGRES_DB
+    os.environ["DB_USERNAME"] = postgres.username
+    os.environ["DB_PASSWORD"] = postgres.password
+    os.environ["DB_NAME"] = postgres.dbname
     customers.create_table()
 
 


### PR DESCRIPTION
Hi folks,

I couldn't find any contributor guidelines, so let me know if this doesn't conform to style or if PRs aren't accepted.

I was recently following this guide: https://testcontainers.com/guides/getting-started-with-testcontainers-for-python/ and ran into two issues.

1. ImportError: no pq wrapper available
1. testcontainers AttributeError: 'Postgres Container' object has no attribute 'POSTGRES_USER'

For #1, it seems that on a M2 mac you need to explicitly install the binary and pool components of psycog. I'm not sure if this is something specific to M2 macs, but thought it might be helpful to update the requirements.txt file.

For #2, the field names for the PostgresContainer seem to have been renamed. I'm not sure if this is specific to the version of TestContainers that's installed or something else.

This PR also adds an entry in .gitignore for __pycache__/ which I thought would be generally useful.

Thanks for reviewing my PR. Let me know how I can improve it and I'll be happy to do so.